### PR TITLE
Linux kernel driver support of libusb_detach_kernel_driver for Linux Kernel >= 3.17

### DIFF
--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -570,13 +570,6 @@ static void airspy_open_device(airspy_device_t* device,
 
 						if (strncmp((const char*)serial_number, serial_number_expected, SERIAL_AIRSPY_EXPECTED_SIZE) == 0)
 						{
-							result = libusb_set_configuration(dev_handle, 1);
-							if (result != 0)
-							{
-								libusb_close(dev_handle);
-								*libusb_dev_handle = NULL;
-								continue;
-							}
 #ifdef __linux__
 							/* Check whether a kernel driver is attached to interface #0. If so, we'll 
 							 * need to detach it.
@@ -586,6 +579,13 @@ static void airspy_open_device(airspy_device_t* device,
 								libusb_detach_kernel_driver(dev_handle, 0);
 							}
 #endif
+							result = libusb_set_configuration(dev_handle, 1);
+							if (result != 0)
+							{
+								libusb_close(dev_handle);
+								*libusb_dev_handle = NULL;
+								continue;
+							}
 							result = libusb_claim_interface(dev_handle, 0);
 							if (result != 0)
 							{
@@ -612,13 +612,6 @@ static void airspy_open_device(airspy_device_t* device,
 				if (libusb_open(dev, libusb_dev_handle) == 0)
 				{
 					dev_handle = *libusb_dev_handle;
-					result = libusb_set_configuration(dev_handle, 1);
-					if (result != 0)
-					{
-						libusb_close(dev_handle);
-						*libusb_dev_handle = NULL;
-						continue;
-					}
 #ifdef __linux__
 					/* Check whether a kernel driver is attached to interface #0. If so, we'll 
 					 * need to detach it.
@@ -628,6 +621,13 @@ static void airspy_open_device(airspy_device_t* device,
 						libusb_detach_kernel_driver(dev_handle, 0);
 					}
 #endif
+					result = libusb_set_configuration(dev_handle, 1);
+					if (result != 0)
+					{
+						libusb_close(dev_handle);
+						*libusb_dev_handle = NULL;
+						continue;
+					}
 					result = libusb_claim_interface(dev_handle, 0);
 					if (result != 0)
 					{

--- a/libairspy/src/airspy.c
+++ b/libairspy/src/airspy.c
@@ -577,6 +577,15 @@ static void airspy_open_device(airspy_device_t* device,
 								*libusb_dev_handle = NULL;
 								continue;
 							}
+#ifdef __linux__
+							/* Check whether a kernel driver is attached to interface #0. If so, we'll 
+							 * need to detach it.
+							 */
+							if (libusb_kernel_driver_active(dev_handle, 0))
+							{
+								libusb_detach_kernel_driver(dev_handle, 0);
+							}
+#endif
 							result = libusb_claim_interface(dev_handle, 0);
 							if (result != 0)
 							{
@@ -610,6 +619,15 @@ static void airspy_open_device(airspy_device_t* device,
 						*libusb_dev_handle = NULL;
 						continue;
 					}
+#ifdef __linux__
+					/* Check whether a kernel driver is attached to interface #0. If so, we'll 
+					 * need to detach it.
+					 */
+					if (libusb_kernel_driver_active(dev_handle, 0))
+					{
+						libusb_detach_kernel_driver(dev_handle, 0);
+					}
+#endif
 					result = libusb_claim_interface(dev_handle, 0);
 					if (result != 0)
 					{


### PR DESCRIPTION
This fix is intended to fix problems towards SDR Linux Kernel >= 3.17 see https://github.com/airspy/host/wiki/Troubleshooting#linux-debianubuntu
So now with this fix it is not required anymore to blacklist airspy linux kernel driver for Linux Kernel >= 3.17