### PR TITLE
Compile fixes for visual studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,18 @@ add_custom_target(uninstall
 ########################################################################
 
 if(WIN32 AND NOT CMAKE_CROSSCOMPILING)
+ if (NOT DEFINED LIBUSB_LIBRARIES)
  configure_file(
      ${CMAKE_CURRENT_BINARY_DIR}/../libs_win32/libusb-1.0.dll
      ${CMAKE_CURRENT_BINARY_DIR}/airspy-tools/src/libusb-1.0.dll
  COPYONLY)
+ endif()
 
+ if (NOT DEFINED THREADS_PTHREADS_WIN32_LIBRARY)
  configure_file(
      ${CMAKE_CURRENT_BINARY_DIR}/../libs_win32/pthreadGC2.dll
      ${CMAKE_CURRENT_BINARY_DIR}/airspy-tools/src/pthreadGC2.dll
  COPYONLY)
+ endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@
 cmake_minimum_required(VERSION 2.8)
 project (airspy_all)
 
+#provide missing strtoull() for VC11
+if(MSVC11)
+    add_definitions(-Dstrtoull=_strtoui64)
+endif(MSVC11)
+
 add_subdirectory(libairspy)
 add_subdirectory(airspy-tools)
 

--- a/libairspy/src/iqconverter_float.c
+++ b/libairspy/src/iqconverter_float.c
@@ -46,7 +46,7 @@ THE SOFTWARE.
   #define FIR_STANDARD
   //#define FIR_AUTO_VECTOR
 #else
-	#if (_MSC_VER >= 1300)
+	#if (_MSC_VER >= 1800)
 		#define USE_SSE2
 		#include <immintrin.h>
 	#else


### PR DESCRIPTION
The following patches fix the build for visual studio, allowing VC11 to compile, and allowing arbitrary libusb and pthread libraries to be specified.

* Referencing this issue: https://github.com/airspy/host/issues/31