### PR TITLE
Use static inline on OS X.

### DIFF
--- a/libairspy/src/iqconverter_float.c
+++ b/libairspy/src/iqconverter_float.c
@@ -36,7 +36,7 @@ THE SOFTWARE.
   #include <malloc/malloc.h>
   #define _aligned_malloc(size, alignment) malloc(size)
   #define _aligned_free(mem) free(mem)
-  #define _inline inline
+  #define _inline static inline
   #define FIR_STANDARD
 #elif defined(__GNUC__) && !defined(__MINGW64_VERSION_MAJOR)
   #include <malloc.h>


### PR DESCRIPTION
This follows the recommendation in [1] and fixes the compile error with
the latest Xcode 8.

[1] http://clang.llvm.org/compatibility.html#inline